### PR TITLE
update outdated brand name

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,17 @@
-import Link from 'next/link';
+import Link from "next/link";
 
 export default function Footer() {
   return (
     <footer className="fixed bottom-0 left-0 w-full flex items-center justify-center gap-4 p-4 border-t z-10 bg-background">
       <span>© {new Date().getFullYear()} Robert Shirts</span>
-      <Link href="https://github.com/robertjshirts/place" className="hover:underline">
+      <Link
+        href="https://github.com/robertjshirts/place"
+        className="hover:underline"
+      >
         GitHub
       </Link>
       <Link href="https://x.com/callanjerel" className="hover:underline">
-        Twitter
+        X
       </Link>
     </footer>
   );


### PR DESCRIPTION
on July 23rd, 2023. The website formerly known as "Twitter" **Officially** rebranded to 'X'.
This change reflects the new branding and will no longer leave users confused.